### PR TITLE
Inject fake HTTP host for indexing

### DIFF
--- a/Classes/Utility/TsfeUtility.php
+++ b/Classes/Utility/TsfeUtility.php
@@ -39,6 +39,8 @@ class TsfeUtility
             $GLOBALS['TSFE']->determineId();
             $GLOBALS['TSFE']->initTemplate();
             $GLOBALS['TSFE']->getConfigArray();
+            $_SERVER['HTTP_HOST'] = 'localhost';
+            GeneralUtility::flushInternalRuntimeCaches();
             $GLOBALS['TSFE']->preparePageContentGeneration();
         }
     }


### PR DESCRIPTION
Flushing the internal runtime caches is necessary here since `HTTP_HOST` is already retrieved once (as `NULL`) early by `PageRenderer::addRequireJsConfiguration()`.