### PR TITLE
Skip pages with "no_search" via query

### DIFF
--- a/Classes/DataCollector/PagesDataCollector.php
+++ b/Classes/DataCollector/PagesDataCollector.php
@@ -111,7 +111,13 @@ class PagesDataCollector extends TcaDataCollector implements DataCollectorInterf
 
         $rawList = $this->pageRepository->getMenu(
             $pid,
-            'uid, doktype, shortcut, shortcut_mode, no_search',
+            implode(',', [
+                'uid',
+                'doktype',
+                'shortcut',
+                'shortcut_mode',
+                'no_search',
+            ]),
             'sorting',
             $whereClause
         );


### PR DESCRIPTION
It does not make much sense to load such pages only to skip them
immediately afterwards.