### PR TITLE
Normalize index type

### DIFF
--- a/Classes/Command/Index/UpdateFullCommand.php
+++ b/Classes/Command/Index/UpdateFullCommand.php
@@ -16,7 +16,7 @@ final class UpdateFullCommand extends AbstractIndexCommand
     {
         $this
             ->setDescription('Process search indexers')
-            ->addArgument('type', InputArgument::OPTIONAL, 'Type to run indexers for');
+            ->addArgument('type', InputArgument::OPTIONAL, 'Type to run indexers for, all by default');
     }
 
     /**
@@ -24,7 +24,7 @@ final class UpdateFullCommand extends AbstractIndexCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->indexingService->indexFull($input->getArgument('type'));
+        $this->indexingService->indexFull($input->getArgument('type') ?: '');
 
         return 0;
     }

--- a/Classes/Command/Index/UpdatePartialCommand.php
+++ b/Classes/Command/Index/UpdatePartialCommand.php
@@ -16,7 +16,7 @@ final class UpdatePartialCommand extends AbstractIndexCommand
     {
         $this
             ->setDescription('Process search indexer updates')
-            ->addArgument('type', InputArgument::OPTIONAL, 'Type to run indexers for');
+            ->addArgument('type', InputArgument::OPTIONAL, 'Type to run indexers for, all by default');
     }
 
     /**
@@ -24,7 +24,7 @@ final class UpdatePartialCommand extends AbstractIndexCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->indexingService->indexPartial($input->getArgument('type'));
+        $this->indexingService->indexPartial($input->getArgument('type') ?: '');
 
         return 0;
     }

--- a/Classes/Service/IndexingService.php
+++ b/Classes/Service/IndexingService.php
@@ -85,11 +85,11 @@ final class IndexingService
     protected $runFullIndexing = false;
 
     /**
-     * Index type. If null, all indexers are run
+     * Index type. If empty, all indexers are run
      *
-     * @var string|null
+     * @var string
      */
-    protected $type = null;
+    protected $type = '';
 
     /**
      * Sets up everything, needs to be run after installation.
@@ -179,7 +179,7 @@ final class IndexingService
      *
      * @param string $type If set, only runs indexing for the given type
      */
-    public function indexFull(string $type = null): void
+    public function indexFull(string $type = ''): void
     {
         $this->assertConnectionHealthy();
 
@@ -195,7 +195,7 @@ final class IndexingService
      *
      * @param string $type If set, only runs indexing for the given type
      */
-    public function indexPartial(string $type = null): void
+    public function indexPartial(string $type = ''): void
     {
         $this->assertConnectionHealthy();
 
@@ -214,7 +214,7 @@ final class IndexingService
         $indices = ExtconfService::getIndices();
 
         foreach ($indices as $language => $index) {
-            if ($this->type == null) {
+            if (empty($this->type)) {
                 foreach ($this->indexerFactory->makeIndexers($language) as $indexer) {
                     $this->scheduledIndexers[$language][] = $indexer;
                 }
@@ -258,7 +258,7 @@ final class IndexingService
             }
         }
 
-        if ($this->type === null) {
+        if (empty($this->type)) {
             IndexManager::getInstance()->resetUpdateIndex();
             $this->logger->info('Update index was reset');
         } else {


### PR DESCRIPTION
The scheduler tasks are stored with an empty string as value for "type"
which is then passed through to the indexing service. To ensure all
types are processed in this case, normalize everything to use an empty
string by default.