### PR TITLE
Prevent result duplication on slow search

### DIFF
--- a/Resources/Public/JavaScript/searchable.js
+++ b/Resources/Public/JavaScript/searchable.js
@@ -108,7 +108,8 @@
 
             }
 
-
+            lastTerm = searchTerm;
+            lastPage = currentPage;
             timer = setTimeout(function(){callAjaxSearch()}, settings.delay);
         }
 
@@ -148,8 +149,6 @@
                         }, data, this);
                     }
 
-                    lastTerm = searchTerm;
-                    lastPage = currentPage;
                     result = data;
                     populate();
                     updateUI();


### PR DESCRIPTION
The search logic happens in a timer, if a search is too slow than the configured delay, the same search will be performed again.
This leads to the same results being appended again and again until the situation normalizes over time.

To avoid this, we directly update the last term and page every time the search is processed instead of doing this after the search results where retrieved.