### PR TITLE
Ignore PHPStan errors about legacy PageRepository

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -40,5 +40,8 @@ parameters:
         - Classes/Utility/TsfeUtility.php
     - message: '#Call to function is_array\(\) with mixed will always evaluate to false.#'
       path: Classes/Feature/Traits/FieldCollectionTrait.php
+    - message: '#.+TYPO3\\CMS\\Frontend\\Page\\PageRepository.+#'
+      paths:
+        - '*'
 
   reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
For some reason PHPStan ignores the class aliases loaded by TYPO3 here.

See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-88746-PageRepositoryPHPClassMovedFromFrontendToCoreExtension.html