### PR TITLE
Index unlocalized tables

### DIFF
--- a/Classes/DataCollector/Utility/OverlayUtility.php
+++ b/Classes/DataCollector/Utility/OverlayUtility.php
@@ -57,6 +57,8 @@ class OverlayUtility implements SingletonInterface
                 'pid' => $record['pid'],
                 $tca['ctrl']['languageField'] => $record[$tca['ctrl']['languageField']],
             ], $language, $overlayMode);
+        } elseif ($language === 0) {
+            return $record;
         }
 
         // PageRepository says this is not a valid record in this language, so don't return it

--- a/Tests/Functional/AbstractElasticsearchTest.php
+++ b/Tests/Functional/AbstractElasticsearchTest.php
@@ -10,6 +10,7 @@ use PAGEmachine\Searchable\Connection;
 use PAGEmachine\Searchable\Indexer\PagesIndexer;
 use PAGEmachine\Searchable\Indexer\TcaIndexer;
 use PAGEmachine\Searchable\LinkBuilder\TypoLinkBuilder;
+use PAGEmachine\Searchable\Preview\NoPreviewRenderer;
 use PAGEmachine\Searchable\Service\IndexingService;
 use Pagemachine\SearchableExtbaseL10nTest\Preview\ContentPreviewRenderer;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
@@ -32,6 +33,7 @@ abstract class AbstractElasticsearchTest extends FunctionalTestCase
     protected $testExtensionsToLoad = [
         'typo3conf/ext/searchable',
         'typo3conf/ext/searchable/Tests/Functional/Fixtures/Extensions/extbase_l10n_test',
+        'typo3conf/ext/searchable/Tests/Functional/Fixtures/Extensions/unlocalized_table_test',
     ];
 
     /**
@@ -123,6 +125,27 @@ abstract class AbstractElasticsearchTest extends FunctionalTestCase
                             ],
                             'preview' => [
                                 'className' => ContentPreviewRenderer::class,
+                            ],
+                            'link' => [
+                                'className' => TypoLinkBuilder::class,
+                            ],
+                        ],
+                    ],
+                    'unlocalized_table' => [
+                        'className' => TcaIndexer::class,
+                        'config' => [
+                            'type' => 'unlocalized_table',
+                            'collector' => [
+                                'config' => [
+                                    'table' => 'tx_unlocalizedtabletest_unlocalizedtable',
+                                    'pid' => 1,
+                                    'fields' => [
+                                        'title',
+                                    ],
+                                ],
+                            ],
+                            'preview' => [
+                                'className' => NoPreviewRenderer::class,
                             ],
                             'link' => [
                                 'className' => TypoLinkBuilder::class,

--- a/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/Configuration/TCA/tx_unlocalizedtabletest_unlocalizedtable.php
+++ b/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/Configuration/TCA/tx_unlocalizedtabletest_unlocalizedtable.php
@@ -1,0 +1,21 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+return [
+    'ctrl' => [
+        'title' => 'Unlocalized Table',
+        'label' => 'title',
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'title',
+        ],
+    ],
+    'columns' => [
+        'title' => [
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "pagemachine/searchable-unlocalized-table-test"
+}

--- a/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/ext_emconf.php
@@ -1,0 +1,11 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Unlocalized Table Test',
+    'version' => '0.0.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '0.0.0',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/ext_tables.sql
+++ b/Tests/Functional/Fixtures/Extensions/unlocalized_table_test/ext_tables.sql
@@ -1,0 +1,9 @@
+CREATE TABLE tx_unlocalizedtabletest_unlocalizedtable (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+
+	title varchar(255) DEFAULT '' NOT NULL,
+
+	PRIMARY KEY (uid),
+	KEY parent (pid)
+);

--- a/Tests/Functional/Service/IndexingServiceTest.php
+++ b/Tests/Functional/Service/IndexingServiceTest.php
@@ -303,6 +303,36 @@ final class IndexingServiceTest extends AbstractElasticsearchTest
     }
 
     /**
+     * @test
+     */
+    public function indexesRecordsOfUnlocalizableTables(): void
+    {
+        $this->getDatabaseConnection()->insertArray('tx_unlocalizedtabletest_unlocalizedtable', [
+            'uid' => 1,
+            'pid' => 1,
+            'title' => 'Test',
+        ]);
+
+        $this->assertIndexEmpty(0);
+        $this->assertIndexEmpty(1);
+
+        $this->indexingService->setup();
+        $this->indexingService->indexFull('unlocalized_table');
+
+        $this->assertDocumentInIndex(
+            1,
+            [
+                'title' => 'Test',
+            ],
+            0,
+        );
+        $this->assertDocumentNotInIndex(
+            1,
+            1,
+        );
+    }
+
+    /**
      * @return void
      */
     protected function setUp(): void


### PR DESCRIPTION
Tables without localization (ctrl/languageField in TCA) are perfectly fine. In this case we should index records of the default language and skip processing for other languages.