### PR TITLE
Properly process deleted records

### DIFF
--- a/Classes/Indexer/Indexer.php
+++ b/Classes/Indexer/Indexer.php
@@ -328,7 +328,7 @@ class Indexer implements IndexerInterface, DynamicConfigurationInterface
 
         if (!empty($updates)) {
             foreach ($this->dataCollector->getUpdatedRecords($updates) as $fullRecord) {
-                if ($fullRecord['deleted'] == 1) {
+                if ($fullRecord['deleted'] ?? 0 == 1) {
                     $this->query->delete($fullRecord['uid']);
                 } else {
                     $counter++;


### PR DESCRIPTION
The indexer checks if a record is marked as deleted and queues a delete from the index. However, TcaDataCollector::processColumns() filters out all columns with "empty" values, which includes "deleted => 0". Thus we need to assume this as fallback here.

Discovered by this exception:
> Warning: Undefined array key "deleted"