### PR TITLE
Drop obsolete functional test environment setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,9 +71,6 @@
         }
     },
     "scripts": {
-        "post-autoload-dump": [
-            "Nimut\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
-        ],
         "analyze:php": "phpstan analyse --ansi --no-progress --configuration=phpstan.neon",
         "build": [
             "@composer require --no-progress --ansi --update-with-dependencies typo3/cms-core $TYPO3_VERSION",


### PR DESCRIPTION
This is obsolete since TYPO3v11.