### PR TITLE
Drop obsolete CI matrix TYPO3v10 excludes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
           - '^11.5'
         elasticsearch:
           - '5'
-        exclude:
-          - php: '8.0'
-            typo3: '^10.4'
-          - php: '8.1'
-            typo3: '^10.4'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
See https://github.com/pagemachine/searchable/pull/92