### PR TITLE
Revert "[TASK] Update typo3/testing-framework (^7.0 => ^8.0)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "squizlabs/php_codesniffer": "^3.0",
         "ssch/typo3-rector": "^2.4",
         "symfony/process": "^5.1",
-        "typo3/testing-framework": "^8.0"
+        "typo3/testing-framework": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Reverts pagemachine/searchable#117

This was merged when CI was broken and no required checks were active.