### PR TITLE
Prevent BE logout in Scheduler module

### DIFF
--- a/Classes/Command/Index/AbstractIndexCommand.php
+++ b/Classes/Command/Index/AbstractIndexCommand.php
@@ -5,6 +5,7 @@ namespace PAGEmachine\Searchable\Command\Index;
 
 use PAGEmachine\Searchable\Service\IndexingService;
 use Symfony\Component\Console\Command\Command;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -22,6 +23,9 @@ abstract class AbstractIndexCommand extends Command
         $this->indexingService = GeneralUtility::makeInstance(IndexingService::class);
 
         Bootstrap::initializeBackendAuthentication();
-        $GLOBALS['BE_USER']->initializeUserSessionManager();
+
+        if ($GLOBALS['BE_USER'] instanceof CommandLineUserAuthentication) {
+            $GLOBALS['BE_USER']->initializeUserSessionManager();
+        }
     }
 }


### PR DESCRIPTION
In TYPO3v12 opening the Scheduler module which contains Searchable indexing tasks did lead to a BE logout.

The reason for this was the "initializeUserSessionManager()" call as performed for all indexing commands. Commands registered as Scheduler tasks are instantiated once to collect them for display in the module. Due to said session manager initialization the existing BE user session was replaced with an anonymous one, effectively resulting in a BE logout.

However, we cannot drop this call completely since it is necessary for the clipboard access in "TYPO3\CMS\Backend\Form\FormDataProvider"; this fails with a BE user without initialized session.

So for now we avoid this issue by checking for the type of the BE user. We now only initialize the user session manager for CLI; in BE/Scheduler everything is already set up.

See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-93023-ReworkedSessionHandling.html
And https://github.com/TYPO3/typo3/blob/4140e8553a2e59045afcf1d4c7287f229f547189/typo3/sysext/backend/Classes/Form/FormDataProvider/TcaGroup.php#L97