### PR TITLE
Ensure integer type for UID passed to RootlineUtility

### DIFF
--- a/Classes/DataCollector/PagesDataCollector.php
+++ b/Classes/DataCollector/PagesDataCollector.php
@@ -188,7 +188,7 @@ class PagesDataCollector extends TcaDataCollector implements DataCollectorInterf
 
         foreach ($pageUids as $uid) {
             try {
-                $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $uid)->get();
+                $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, (int)$uid)->get();
 
                 if (in_array($rootlinePageUid, array_column($rootLine, 'uid'), true)) {
                     $filteredPageUids[] = $uid;


### PR DESCRIPTION
The list of page UIDs processed here is the result of a ES query where the values are numeric strings. Since TYPO3v12 the RootlineUtility uses native types and now strictly expects an integer.

See https://github.com/TYPO3/typo3/commit/91462d7bccf3325870a04fba9d5ae4904c4219fe