### PR TITLE
Remove obsolete AddLiteralSeparatorToNumberRector skip

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
-use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 
@@ -24,7 +23,6 @@ return RectorConfig::configure()
         Typo3SetList::TYPO3_11,
     ])
     ->withSkip([
-        AddLiteralSeparatorToNumberRector::class,
         RemoveExtraParametersRector::class => [
             __DIR__ . '/Classes/DataCollector/TCA/FormDataRecord.php',
             __DIR__ . '/Classes/DataCollector/Utility/OverlayUtility.php',


### PR DESCRIPTION
This is not loaded anymore with PHP > 7.4.