### PR TITLE
Move partial index into the typo3 database

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -1,7 +1,6 @@
 <?php
 namespace PAGEmachine\Searchable\Controller;
 
-use PAGEmachine\Searchable\Connection;
 use PAGEmachine\Searchable\Domain\Repository\UpdateRepository;
 use PAGEmachine\Searchable\Indexer\IndexerFactory;
 use PAGEmachine\Searchable\IndexManager;

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -2,6 +2,7 @@
 namespace PAGEmachine\Searchable\Controller;
 
 use PAGEmachine\Searchable\Connection;
+use PAGEmachine\Searchable\Domain\Repository\UpdateRepository;
 use PAGEmachine\Searchable\Indexer\IndexerFactory;
 use PAGEmachine\Searchable\IndexManager;
 use PAGEmachine\Searchable\Query\SearchQuery;
@@ -19,17 +20,22 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class BackendController extends ActionController
 {
-    /**
-     * @var IndexerFactory $indexerFactory
-     */
-    protected $indexerFactory;
-    public function __construct(private readonly ModuleTemplateFactory $moduleTemplateFactory)
-    {
-    }
+    protected IndexerFactory $indexerFactory;
+
+    protected UpdateRepository $updateRepository;
 
     public function injectIndexerFactory(IndexerFactory $indexerFactory): void
     {
         $this->indexerFactory = $indexerFactory;
+    }
+
+    public function injectUpdateRepository(UpdateRepository $updateRepository): void
+    {
+        $this->updateRepository = $updateRepository;
+    }
+
+    public function __construct(private readonly ModuleTemplateFactory $moduleTemplateFactory)
+    {
     }
 
     /**
@@ -55,25 +61,10 @@ class BackendController extends ActionController
     /**
      * Fetches scheduled updates for backend module
      *
-     * @return array
      */
     protected function fetchScheduledUpdates()
     {
-        $client = Connection::getClient();
-
-        $updates = $client->search([
-            'index' => ExtconfService::getInstance()->getUpdateIndex(),
-            'type' => '',
-            'body' => [
-                'query' => [
-                    'match_all' => new \stdClass(),
-                ],
-            ],
-        ]);
-
-        $updates['count'] = $client->count(['index' => ExtconfService::getInstance()->getUpdateIndex()])['count'];
-
-        return $updates;
+        return $this->updateRepository->findAll();
     }
 
     /**

--- a/Classes/Domain/Model/Update.php
+++ b/Classes/Domain/Model/Update.php
@@ -1,0 +1,74 @@
+<?php
+namespace PAGEmachine\Searchable\Domain\Model;
+
+/*
+ * This file is part of the PAGEmachine Searchable project.
+ */
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class Update extends AbstractEntity
+{
+    /**
+     * @var string
+     */
+    protected $type = '';
+
+    /**
+     * @var string
+     */
+    protected $property = '';
+
+    /**
+     * @var int
+     */
+    protected $propertyUid = 0;
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param string $property
+     */
+    public function setProperty(string $property): void
+    {
+        $this->property = $property;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPropertyUid(): int
+    {
+        return $this->propertyUid;
+    }
+
+    /**
+     * @param int $propertyUid
+     */
+    public function setPropertyUid(int $propertyUid): void
+    {
+        $this->propertyUid = $propertyUid;
+    }
+}

--- a/Classes/Domain/Repository/UpdateRepository.php
+++ b/Classes/Domain/Repository/UpdateRepository.php
@@ -1,0 +1,64 @@
+<?php
+namespace PAGEmachine\Searchable\Domain\Repository;
+
+/*
+ * This file is part of the PAGEmachine Searchable project.
+ */
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class UpdateRepository extends Repository
+{
+    private const TABLE_NAME = 'tx_searchable_domain_model_update';
+
+    private ConnectionPool $connectionPool;
+
+    public function injectConnectionPool(ConnectionPool $connectionPool): void
+    {
+        $this->connectionPool = $connectionPool;
+    }
+
+    public function initializeObject(): void
+    {
+        $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
+        $querySettings->setRespectStoragePage(false);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    public function insertUpdate(
+        string $type,
+        string $property,
+        int $propertyUid,
+    ): void {
+        try {
+            $this->connectionPool
+                ->getConnectionForTable(self::TABLE_NAME)
+                ->insert(
+                    self::TABLE_NAME,
+                    [
+                        'type' => $type,
+                        'property' => $property,
+                        'property_uid' => $propertyUid,
+                    ],
+                );
+        } catch (UniqueConstraintViolationException $e) {
+            // Ignore duplicate entry error
+        }
+    }
+
+    public function deleteAll()
+    {
+        foreach ($this->findAll() as $object) {
+            $this->connectionPool->getConnectionForTable(self::TABLE_NAME)
+                ->delete(
+                    self::TABLE_NAME,
+                    ['uid' => $object->getUid()],
+                );
+        }
+
+    }
+}

--- a/Classes/Domain/Repository/UpdateRepository.php
+++ b/Classes/Domain/Repository/UpdateRepository.php
@@ -45,7 +45,7 @@ class UpdateRepository extends Repository
                         'property_uid' => $propertyUid,
                     ],
                 );
-        } catch (UniqueConstraintViolationException $e) {
+        } catch (UniqueConstraintViolationException) {
             // Ignore duplicate entry error
         }
     }
@@ -59,6 +59,5 @@ class UpdateRepository extends Repository
                     ['uid' => $object->getUid()],
                 );
         }
-
     }
 }

--- a/Classes/Query/UpdateQuery.php
+++ b/Classes/Query/UpdateQuery.php
@@ -2,7 +2,6 @@
 namespace PAGEmachine\Searchable\Query;
 
 use PAGEmachine\Searchable\Domain\Repository\UpdateRepository;
-use PAGEmachine\Searchable\Service\ExtconfService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /*

--- a/Classes/Query/UpdateQuery.php
+++ b/Classes/Query/UpdateQuery.php
@@ -1,7 +1,9 @@
 <?php
 namespace PAGEmachine\Searchable\Query;
 
+use PAGEmachine\Searchable\Domain\Repository\UpdateRepository;
 use PAGEmachine\Searchable\Service\ExtconfService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /*
  * This file is part of the PAGEmachine Searchable project.
@@ -13,13 +15,16 @@ use PAGEmachine\Searchable\Service\ExtconfService;
  */
 class UpdateQuery extends AbstractQuery
 {
+    protected UpdateRepository $updateRepository;
+
     /**
      * @return void
      */
     public function __construct()
     {
         parent::__construct();
-        $this->setIndices([ExtconfService::getInstance()->getUpdateIndex()]);
+
+        $this->updateRepository = GeneralUtility::makeInstance(UpdateRepository::class);
 
         $this->init();
     }
@@ -31,35 +36,18 @@ class UpdateQuery extends AbstractQuery
     public function init()
     {
         $this->parameters =  [
-            'index' => implode(',', $this->getIndices()),
-            'body' => [
-            ],
+            'index' => [],
+            'body' => [],
         ];
     }
 
     /**
      * Adds a new update query string
      *
-     * @return array
      */
-    public function addUpdate($type, $property, $id)
+    public function addUpdate($type, $property, $id): void
     {
-        // Use querystring hash as id to mark each update only once
-        $docid = sha1($type . "." . $property . ":" . $id);
-
-        $this->parameters['id'] = $docid;
-        $this->parameters['type'] = '_doc';
-        $this->parameters['body']['type'] = strval($type);
-        $this->parameters['body']['property'] = $property;
-        $this->parameters['body']['uid'] = $id;
-
-        try {
-            $response = $this->client->index($this->getParameters());
-            return $response;
-        } catch (\Exception $e) {
-            $this->logger->error("Could not track update. Reason: " . $e->getMessage());
-            return [];
-        }
+        $this->updateRepository->insertUpdate($type, $property, $id);
     }
 
     /**
@@ -69,39 +57,22 @@ class UpdateQuery extends AbstractQuery
      */
     public function getUpdates($index, $type)
     {
-        $recordids = [];
-
         $this->init();
 
-        $this->parameters['body'] = [
-            'query' => [
-                'bool' => [
-                    'filter' => [
-                        'term' => [
-                            'type' => $type,
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $recordids = [];
 
-
-        $result = $this->client->search($this->parameters);
-
-        if (empty($result['hits']['hits'])) {
-            return [];
-        }
+        $results = $this->updateRepository->findByType($type);
 
         $updateParams = [];
 
-        foreach ($result['hits']['hits'] as $hit) {
+        foreach ($results as $hit) {
             //If this is a simple toplevel uid check, we can add this id directly to the updated uid list
-            if ($hit['_source']['property'] == 'uid') {
-                $recordids[$hit['_source']['uid']] = $hit['_source']['uid'];
+            if ($hit->getProperty() == 'uid') {
+                $recordids[$hit->getPropertyUid()] = $hit->getPropertyUid();
             } else {
                 $updateParams[] = [
                     "term" => [
-                        $hit['_source']['property'] => $hit['_source']['uid'],
+                        $hit->getProperty() => $hit->getPropertyUid(),
                     ],
                 ];
             }
@@ -124,7 +95,7 @@ class UpdateQuery extends AbstractQuery
 
             if (!empty($result['hits']['hits'])) {
                 foreach ($result['hits']['hits'] as $hit) {
-                    $recordids[$hit['_id']] = $hit['_id'];
+                    $recordids[$hit['_id']] = (int) $hit['_id'];
                 }
             }
         }

--- a/Classes/Service/ExtconfService.php
+++ b/Classes/Service/ExtconfService.php
@@ -226,15 +226,6 @@ class ExtconfService implements SingletonInterface
     }
 
     /**
-     * Returns the update index
-     * @return string
-     */
-    public function getUpdateIndex()
-    {
-        return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['searchable']['updateIndex']['name'];
-    }
-
-    /**
      * Returns the hosts configuration
      *
      * @return array

--- a/Classes/Service/IndexingService.php
+++ b/Classes/Service/IndexingService.php
@@ -89,11 +89,6 @@ final class IndexingService implements \Stringable
         $this->logger->debug('Checking for existing Update Index..');
 
         $indexManager = IndexManager::getInstance();
-        $indexManager->createIndex(
-            ExtconfService::getInstance()->getUpdateIndex()
-        );
-        $this->logger->debug('Ensured update index exists');
-
         $indices = ExtconfService::getIndices();
 
         try {

--- a/Configuration/TCA/tx_searchable_domain_model_update.php
+++ b/Configuration/TCA/tx_searchable_domain_model_update.php
@@ -1,0 +1,55 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Searchable Update Index',
+        'hideTable' => true,
+    ],
+    'interface' => [
+        'showRecordFieldList' => 'type,property,property_uid',
+    ],
+    'columns' => [
+        'type' => [
+            'exclude' => true,
+            'label' => 'Type',
+            'config' => [
+                'type' => 'input',
+                'size' => 255,
+                'max' => 255,
+                'eval' => 'trim',
+                'readOnly' => true,
+            ],
+        ],
+        'property' => [
+            'exclude' => true,
+            'label' => 'Property',
+            'config' => [
+                'type' => 'input',
+                'size' => 255,
+                'max' => 255,
+                'eval' => 'trim',
+                'readOnly' => true,
+            ],
+        ],
+        'property_uid' => [
+            'exclude' => true,
+            'label' => 'Property UID',
+            'config' => [
+                'type' => 'input',
+                'size' => 11,
+                'eval' => 'int',
+                'readOnly' => true,
+            ],
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'type, property, property_uid',
+        ],
+    ],
+    'palettes' => [
+        '1' => [
+            'showitem' => '',
+        ],
+    ],
+];

--- a/Resources/Private/Templates/Backend/Start.html
+++ b/Resources/Private/Templates/Backend/Start.html
@@ -43,7 +43,7 @@
 		</div>
 
 		<h2>Update schedule</h2>
-		<p>{updates.count} updates scheduled.</p>
+		<p><f:count>{updates}</f:count> updates scheduled.</p>
 
 		<table class="table">
 			<tr>
@@ -52,11 +52,11 @@
 				<th>Uid</th>
 			</tr>
 
-			<f:for each="{updates.hits.hits}" as="update">
+			<f:for each="{updates}" as="update">
 				<tr>
-				 <td>{update._source.type}</td>
-				 <td>{update._source.property}</td>
-				 <td>{update._source.uid}</td>
+				 <td>{update.type}</td>
+				 <td>{update.property}</td>
+				 <td>{update.propertyUid}</td>
 				</tr>
 			</f:for>
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -81,10 +81,6 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['searchable'] = [
     // The fieldname to store meta information in (link, preview etc.). This field will be added to all created ES types and set to index = false
     // Note that this field will also affect how you can access the meta fields in templates!
     'metaField' => 'searchable_meta',
-    //Update index. Used for storing the records to update in the next indexing run
-    'updateIndex' => [
-        'name' => 'searchable_updates',
-    ],
     //Add indices here. Default format: language UID => index configuration
     'indices' => [],
     //Add your indexer configurations here. Each indexer represents a toplevel object type like news, pages etc.

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,10 @@
+#
+# Table structure for table 'tx_searchable_domain_model_update'
+#
+CREATE TABLE tx_searchable_domain_model_update (
+	type varchar(255) NOT NULL,
+	property varchar(255) NOT NULL,
+	property_uid int(11) NOT NULL,
+
+	UNIQUE KEY element (type, property, property_uid)
+);


### PR DESCRIPTION
By moving the partial index from elasticsearch to typo3 it decouples the typo3 save process from elasticsearch. The current implementation results in long saving times in the typo3 backend if the Elasticsearch server was responding slow. 