### PR TITLE
Skip hidden content/records on indexing

### DIFF
--- a/Classes/Command/Index/AbstractIndexCommand.php
+++ b/Classes/Command/Index/AbstractIndexCommand.php
@@ -6,7 +6,10 @@ namespace PAGEmachine\Searchable\Command\Index;
 use PAGEmachine\Searchable\Service\IndexingService;
 use Symfony\Component\Console\Command\Command;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 abstract class AbstractIndexCommand extends Command
@@ -26,6 +29,23 @@ abstract class AbstractIndexCommand extends Command
 
         if ($GLOBALS['BE_USER'] instanceof CommandLineUserAuthentication) {
             $GLOBALS['BE_USER']->initializeUserSessionManager();
+        }
+
+        $context = GeneralUtility::makeInstance(Context::class);
+        $currentVisibilityAspect = $context->getAspect('visibility');
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            $context->setAspect('visibility', new VisibilityAspect(
+                includeHiddenPages: $currentVisibilityAspect->includeHiddenPages(),
+                includeHiddenContent: false,
+                includeDeletedRecords: $currentVisibilityAspect->includeDeletedRecords(),
+            ));
+        } else {
+            $context->setAspect('visibility', new VisibilityAspect(
+                includeHiddenPages: $currentVisibilityAspect->includeHiddenPages(),
+                includeHiddenContent: false,
+                includeDeletedRecords: $currentVisibilityAspect->includeDeletedRecords(),
+                includeScheduledRecords: $currentVisibilityAspect->includeScheduledRecords(),
+            ));
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Context\\\\VisibilityAspect\\:\\:includeScheduledRecords\\(\\)\\.$#"
+			count: 1
+			path: Classes/Command/Index/AbstractIndexCommand.php
+
+		-
+			message: "#^Unknown parameter \\$includeScheduledRecords in call to TYPO3\\\\CMS\\\\Core\\\\Context\\\\VisibilityAspect constructor\\.$#"
+			count: 1
+			path: Classes/Command/Index/AbstractIndexCommand.php
+
+		-
 			message: "#^Method TYPO3\\\\CMS\\\\Backend\\\\Form\\\\FormDataCompiler\\:\\:compile\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: Classes/DataCollector/TCA/FormDataRecord.php


### PR DESCRIPTION
The "visibility" aspect set up by the TYPO3 CommandApplication includes hidden content (and thus records) by default. This can be seen especially when using the Extbase persistence during the indexing process. Related objects ignore any enable fields and are loaded unconditionally.

This whole topic very likely needs further investigation and additional restrictions (e.g. skip hidden pages and scheduled records) but left for another change.