### PR TITLE
Remove page tree from BE module

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -17,5 +17,6 @@ return [
                 'start', 'search', 'request', 'resetIndices', 'indexFull', 'indexPartial',
             ],
         ],
+        'inheritNavigationComponentFromMainModule' => false,
     ],
 ];


### PR DESCRIPTION
The backend module does not interact with the page tree, so it doesn't make sense to have it displayed here.