### PR TITLE
Use first index in BE "request" action

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -123,7 +123,8 @@ class BackendController extends ActionController
             ]);
         } else {
             $hosts = ExtconfService::getInstance()->getHostsSettings();
-            $url = sprintf('%s/typo3/', $hosts[0] ?? 'http://localhost:9200');
+            $indices = ExtconfService::getInstance()->getIndices();
+            $url = sprintf('%s/%s/', $hosts[0] ?? 'http://localhost:9200', $indices[0] ?? 'typo3');
         }
 
         $this->view->assign("url", $url);


### PR DESCRIPTION
This ensures that one gets at least a successful response instead of an error due to the undefined "typo3" index.