### PR TITLE
Skip and log URI building errors

### DIFF
--- a/Classes/LinkBuilder/Frontend/FrontendRequest.php
+++ b/Classes/LinkBuilder/Frontend/FrontendRequest.php
@@ -31,7 +31,7 @@ final class FrontendRequest implements FrontendRequestInterface
                 'http_errors' => false,
             ]
         );
-        // \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump((string)$response->getBody(), __METHOD__, 8, defined('TYPO3_cliMode') || defined('TYPO3_REQUESTTYPE') && (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI));
+
         $uris = json_decode((string)$response->getBody(), true);
 
         return $uris;


### PR DESCRIPTION
The whole setup must be more robust but this allows at least some URIs to be built successfully.