### PR TITLE
Enable caching for "Live search bar" plugin

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,9 +37,6 @@ ExtensionUtility::configurePlugin(
     'LiveSearchbar',
     [
         SearchController::class => 'liveSearchbar',
-    ],
-    [
-        SearchController::class => 'liveSearchbar',
     ]
 );
 


### PR DESCRIPTION
This plugin is stateless and not affected e.g. by the search term. So we can actually enable caching for this plugin.