### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "symfony/console": "^6.4 || ^7.0",
-        "symfony/polyfill-php80": "^1.26",
         "typo3/cms-backend": "^12.4 || ^13.4",
         "typo3/cms-core": "^12.4 || ^13.4",
         "typo3/cms-extbase": "^12.4 || ^13.4",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.2`, so the polyfill requirement doesn't seem necessary anymore?