### PR TITLE
Ignore PHPStan "pageNotFound" fallback chain order error

### DIFF
--- a/Classes/DataCollector/Utility/OverlayUtility.php
+++ b/Classes/DataCollector/Utility/OverlayUtility.php
@@ -138,7 +138,7 @@ class OverlayUtility implements SingletonInterface
                                 $languageContentId = (int)$orderValue;
                                 break;
                             }
-                            if ($orderValue === 'pageNotFound') {
+                            if ($orderValue === 'pageNotFound') { // @phpstan-ignore identical.alwaysFalse
                                 // The existing fallbacks have not been found, but instead of continuing page rendering
                                 // with default language, a "page not found" message should be shown instead.
                                 throw new PageNotFoundException('Page is not available in the requested language (fallbacks did not apply).', 1754384524);


### PR DESCRIPTION
Not exactly sure where the "float|int|numeric-string" type comes from here but "pageNotFound" is a valid entry in the fallback chain.

See https://github.com/TYPO3/typo3/blob/v14.3.2/typo3/sysext/core/Classes/Context/LanguageAspectFactory.php#L35 And https://github.com/TYPO3/typo3/blob/v13.4.30/typo3/sysext/core/Classes/Context/LanguageAspectFactory.php#L35