### PR TITLE
Retry Elasticsearch connection

### DIFF
--- a/Classes/Connection.php
+++ b/Classes/Connection.php
@@ -32,6 +32,7 @@ class Connection
         if (self::$client == null) {
             self::$client = ClientBuilder::create()
                 ->setHosts(ExtconfService::getInstance()->getHostsSettings())
+                ->setRetries(5)
                 ->build();
         }
         return self::$client;


### PR DESCRIPTION
This improves connectivity in case of flaky services, mostly due to slow startup but possibly also at runtime.